### PR TITLE
Fixes the average formula

### DIFF
--- a/droll.js
+++ b/droll.js
@@ -68,7 +68,7 @@
 
     result.minResult = (result.numDice * 1) + result.modifier;
     result.maxResult = (result.numDice * result.numSides) + result.modifier;
-    result.avgResult = (result.maxResult - result.minResult) / 2;
+    result.avgResult = (result.maxResult + result.minResult) / 2;
 
     return result;
   };

--- a/test/droll.test.js
+++ b/test/droll.test.js
@@ -23,7 +23,7 @@ describe('droll#parse(formula)', function() {
     result.modifier.should.equal(1);
     result.minResult.should.equal(4);
     result.maxResult.should.equal(19);
-    result.avgResult.should.equal(7.5);
+    result.avgResult.should.equal(11.5);
   });
 
   it('should return false when given an invalid formula', function() {


### PR DESCRIPTION
The formula should use a **+** instead of a **-**.

An easy way to confirm this is by rolling *1d2*. Previously, `avgResult` would be 0.5 but the average shouldn't be lower than `minResult` (1). Now its 1.5.

I also modified the test file to work with the new formula but I didn't  change the minified version as it seems to be automated at the release task.

Thank you for this amazing library. It's been very helpful for my project.