### PR TITLE
Replace Math.random with uniform distributed random values

### DIFF
--- a/droll.js
+++ b/droll.js
@@ -3,8 +3,8 @@
    "use strict";
 
   var droll = {};
-  let Random = require("random-js");
-  let engine = Random.engines.mt19937().autoSeed();
+  var Random = require("random-js");
+  var engine = Random.engines.mt19937().autoSeed();
 
 
 
@@ -96,7 +96,7 @@
     pieces = droll.parse(formula);
     if (!pieces) { return false; }
 
-    let distribution = Random.integer(1, pieces.numSides);
+    var distribution = Random.integer(1, pieces.numSides);
     for (var a=0; a<pieces.numDice; a++) {
         result.rolls[a] = distribution(engine);
     }

--- a/droll.js
+++ b/droll.js
@@ -3,13 +3,17 @@
    "use strict";
 
   var droll = {};
+  let Random = require("random-js");
+  let engine = Random.engines.mt19937().autoSeed();
+
+
 
   // Define a "class" to represent a formula
   function DrollFormula() {
     this.numDice   = 0;
     this.numSides  = 0;
     this.modifier  = 0;
-    
+
     this.minResult = 0;
     this.maxResult = 0;
     this.avgResult = 0;
@@ -92,8 +96,9 @@
     pieces = droll.parse(formula);
     if (!pieces) { return false; }
 
+    let distribution = Random.integer(1, pieces.numSides);
     for (var a=0; a<pieces.numDice; a++) {
-      result.rolls[a] = (1 + Math.floor(Math.random() * pieces.numSides));
+        result.rolls[a] = distribution(engine);
     }
 
     result.modifier = pieces.modifier;

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
   "scripts"         : {
                         "test" : "grunt --verbose"
                       },
+  "dependencies":     {
+                        "random-js": "^1.0.8"
+                      },
   "devDependencies" : {
                         "mocha"                : "1.14.x",
                         "should"               : "2.1.x",


### PR DESCRIPTION
Problem:
Math.random produces uniformly distributed numbers within the range of (0, 1], but trying to map those values integer range with `Math.floor(Math.random() * pieces.numSides)` leads to slightly biased results.

Solution:
Add a dependency on [random-js](https://github.com/ckknight/random-js).
random-js provides an interface that allows you to specify both the source (algorithm) of the random number generator and the desired distribution. In this case a uniform integer distribution over the range of 1 to `pieces.numSides`.